### PR TITLE
Fix InfSampler minor bug when shuffle is False

### DIFF
--- a/pretrain/pointcontrast/lib/data_sampler.py
+++ b/pretrain/pointcontrast/lib/data_sampler.py
@@ -20,6 +20,8 @@ class InfSampler(Sampler):
     perm = len(self.data_source)
     if self.shuffle:
       perm = torch.randperm(perm)
+    else:
+      perm = torch.arange(perm)
     self._perm = perm.tolist()
 
   def __iter__(self):


### PR DESCRIPTION
Fix the problem that when `shuffle` is False (which does not happen here), the operation `len(self.data_source).tolist()` will cause error.